### PR TITLE
Update seq.docker-compose.yaml

### DIFF
--- a/src/docker-compose/services/seq/seq.docker-compose.yaml
+++ b/src/docker-compose/services/seq/seq.docker-compose.yaml
@@ -13,6 +13,7 @@ services:
     ports:
       - "5341:5341"
       - "45341:45341"
+      - "5342:80"
     networks:
       default:
         aliases:


### PR DESCRIPTION
Seq didn't have an UI port exposed. This PR allows the UI port to be exposed and accessible.